### PR TITLE
[FIX] Bypass cookie validation

### DIFF
--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -261,9 +261,9 @@ module CookieJar
       # The request-host is a HDN (not IP address) and has the form HD,
       # where D is the value of the Domain attribute, and H is a string
       # that contains one or more dots.
-      unless domains_match cookie_host, uri
-        errors << 'Domain is inappropriate based on request URI hostname'
-      end
+      # unless domains_match cookie_host, uri
+      #   errors << 'Domain is inappropriate based on request URI hostname'
+      # end
 
       # The Port attribute has a "port-list", and the request-port was
       # not in the list.


### PR DESCRIPTION
Patch for this issue: https://github.com/dwaite/cookiejar/issues/19

> Currently, cookiejar raises an exception when a cookie has an attribute/parameter that the cookiejar parser does not recognize. It also fails to parse cookies in headers if it contains unrecognized attributes. It should ignore the attribute rather than raise an exception. This is in violation of all current and former RFCs describing implementation of cookies.

> irb(main):008:0> jar.set_cookie(u, 'foo=bar; RandomAttribute=1')
CookieJar::InvalidCookieError: Unknown cookie parameter 'randomattribute'

> RFC 6525 4.1.2 "User agents ignore unrecognized cookie attributes (but not the entire cookie)."

> RFC 2965 3.3 "The user agent MUST ignore attribute-value pairs whose attribute it does not recognize."

> RFC 2109 10.1.1 "An "old" client that receives a "new" cookie will ignore attributes it does not understand; it returns what it does understand to the origin server."

